### PR TITLE
Use `GeoInterface.geometrycolumns`

### DIFF
--- a/src/SpatialDependence.jl
+++ b/src/SpatialDependence.jl
@@ -10,7 +10,7 @@ module SpatialDependence
     using PlotUtils: palette
     using Random: shuffle, AbstractRNG, default_rng
     using RecipesBase
-    using Tables: istable
+    using Tables: istable, getcolumn
 
     import Base: length
     import SparseArrays: SparseMatrixCSC, sparse

--- a/src/sweights/polyneigh.jl
+++ b/src/sweights/polyneigh.jl
@@ -165,12 +165,9 @@ function polyneigh(A::Any; criterion::Symbol = :Queen, tol::Float64 = 0.0)::Spat
     return polyneigh(geomcol, criterion = criterion, tol = tol)
 end
 
+# Internal function to get the geometry column from a Table
 function _geomFromTable(A::Any)
-    if :geometry in propertynames(A)
-        geomcol = A.geometry
-    else
-        (:geom in propertynames(A)) || throw(ArgumentError("table does not have :geometry or :geom information"))
-        geomcol = A.geom
-    end
-    return geomcol
+    geomcol = first(GeoInterface.geometrycolumns(A))
+    geomcol in  propertynames(A) || throw(ArgumentError("table does not have geometry information :$geomcol"))
+    return getcolumn(A, geomcol)
 end

--- a/test/guerry.jl
+++ b/test/guerry.jl
@@ -229,13 +229,4 @@
         @test score(goguerry)[1:5] ≈ [0.064923; 0.113616; 0.044785; 0.065224; 0.055906] atol = 1e-5
         @test score(goguerry)[81:85] ≈ [0.046589; 0.054704; 0.043282; 0.140667; 0.084761] atol = 1e-5
     end
-
-
-    # Test table with :geom column instead of :geometry
-    @testset "Table with :geom" begin
-        guerrygeom = guerry[:,2:end]
-        guerrygeom.geom = guerry.geometry
-        @test_nowarn polyneigh(guerrygeom)
-    end
-
 end


### PR DESCRIPTION
Use `GeoInterface.geometrycolumns` to get the geometry column of a table.